### PR TITLE
Release v1.0.2 #13 – Pass the pick date date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.1.0]
+
+- User can get the pick date data as a list of DateTime, not just a single DateTime.
+- Modularized `CalendarDateCell` and `getRangeDecoration` logic
+- Fixed logical prioritization in decoration application for user-picked and range cells
+- Improved `MCalendar` UI with card layout, theme consistency, and styling polish
+- Added full Dart documentation for all public classes and functions
+
 ## [1.0.2]
 
 - Beautified calendar example in `README.md`

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Add this to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  m_calendar: ^1.0.2
+  m_calendar: ^1.1.0

--- a/lib/m_calendar.dart
+++ b/lib/m_calendar.dart
@@ -23,6 +23,8 @@ class MCalendar extends StatelessWidget {
     this.isRangeSelection,
     this.userPickedDecoration,
     this.userPickedChild,
+    this.cellPadding,
+    required this.onUserPicked,
   });
 
   /// The month to be displayed in the calendar.
@@ -53,6 +55,12 @@ class MCalendar extends StatelessWidget {
   /// The widget to display in a user-picked cell.
   final Widget? userPickedChild;
 
+  /// Padding applied to the cell content.
+  final EdgeInsets? cellPadding;
+
+  /// the function return the userPickDate value
+  final void Function(List<DateTime>)? onUserPicked;
+
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
@@ -62,6 +70,7 @@ class MCalendar extends StatelessWidget {
                 selectedMonth ?? DateTime.now(),
                 markedDaysList,
                 isRangeSelection ?? false,
+                onUserPicked: onUserPicked,
               ),
       child: Consumer<CalenderTableProvider>(
         builder: (_, provider, __) {
@@ -97,6 +106,7 @@ class MCalendar extends StatelessWidget {
                     defaultChild: defaultChild,
                     userPickedDecoration: userPickedDecoration,
                     userPickedChild: userPickedChild,
+                    cellPadding: cellPadding,
                   ),
                 ],
               ),
@@ -115,6 +125,7 @@ class MCalendar extends StatelessWidget {
     Widget? userPickedChild,
     BoxDecoration? decoration,
     BoxDecoration? userPickedDecoration,
+    EdgeInsets? cellPadding,
     required CalenderTableProvider provider,
   }) {
     final List<Widget> dayCells = [];
@@ -133,6 +144,7 @@ class MCalendar extends StatelessWidget {
           defaultChild: defaultChild,
           userPickedDecoration: userPickedDecoration,
           userPickedChild: userPickedChild,
+          cellPadding: cellPadding,
         ),
       );
     }

--- a/lib/model/marked_date_model.dart
+++ b/lib/model/marked_date_model.dart
@@ -5,10 +5,10 @@ import 'package:flutter/material.dart';
 /// The [MarkedDaysModel] is used to define which days should be visually
 /// decorated on a calendar, along with optional custom widgets.
 class MarkedDaysModel {
-  /// Creates a [MarkedDaysModel] with a list of selected days,
+  /// Creates a [MarkedDaysModel] with a list of selected dates,
   /// a decoration to apply, and an optional child widget.
   ///
-  /// - [selectedDateList] should contain the day numbers (1–31) you want to mark.
+  /// - [selectedDateList] should contain full [DateTime] values.
   /// - [decoration] is the visual styling applied to those marked days.
   /// - [child] is an optional widget to overlay on those decorated days.
   MarkedDaysModel({
@@ -17,17 +17,13 @@ class MarkedDaysModel {
     this.child,
   });
 
-  /// A list of integers representing the day numbers (1 to 31)
+  /// A list of [DateTime] objects representing the exact days
   /// that should be marked on the calendar.
-  final List<int> selectedDateList;
+  final List<DateTime> selectedDateList;
 
   /// The visual decoration to apply to the marked days.
-  ///
-  /// This can include background color, border, shape, etc.
   final BoxDecoration decoration;
 
   /// An optional widget to display on top of the decorated day cell.
-  ///
-  /// This could be a label, icon, or any custom indicator.
   final Widget? child;
 }

--- a/lib/utils/range_decoration.dart
+++ b/lib/utils/range_decoration.dart
@@ -27,16 +27,22 @@ BoxDecoration getRangeDecoration({
   BoxDecoration? defaultDecoration,
   required Color baseColor,
 }) {
+  if (rangeStart == rangeEnd) {
+    return BoxDecoration(
+      color: baseColor.withAlpha(100),
+      borderRadius: BorderRadius.circular(32),
+    );
+  }
   if (i == rangeStart) {
     return BoxDecoration(
-      color: baseColor,
+      color: baseColor.withAlpha(100),
       borderRadius: const BorderRadius.horizontal(left: Radius.circular(32)),
     );
   }
 
   if (i == rangeEnd) {
     return BoxDecoration(
-      color: baseColor,
+      color: baseColor.withAlpha(100),
       borderRadius: const BorderRadius.horizontal(right: Radius.circular(32)),
     );
   }
@@ -46,7 +52,7 @@ BoxDecoration getRangeDecoration({
       i > rangeStart &&
       i < rangeEnd) {
     return BoxDecoration(
-      color: baseColor.withOpacity(0.5),
+      color: baseColor.withAlpha(100),
       borderRadius: BorderRadius.zero,
     );
   }

--- a/lib/widgets/calendar_date_cell.dart
+++ b/lib/widgets/calendar_date_cell.dart
@@ -25,6 +25,7 @@ class CalendarDateCell extends StatelessWidget {
     this.userSelectedItemStyle,
     this.userPickedDecoration,
     this.userPickedChild,
+    this.cellPadding,
   });
 
   /// The day of the month represented by this cell (1-based index).
@@ -45,12 +46,25 @@ class CalendarDateCell extends StatelessWidget {
   /// Custom widget displayed when the cell is picked by the user.
   final Widget? userPickedChild;
 
+  /// Padding applied to the cell content.
+  final EdgeInsets? cellPadding;
+
   @override
   Widget build(BuildContext context) {
     final provider = Provider.of<CalenderTableProvider>(context);
+    final currentDate = DateTime(
+      provider.selectedMonth.year,
+      provider.selectedMonth.month,
+      i,
+    );
 
     final selectedModel = provider.selectedDaysList.firstWhere(
-      (model) => model.selectedDateList.contains(i),
+      (model) => model.selectedDateList.any(
+        (d) =>
+            d.year == currentDate.year &&
+            d.month == currentDate.month &&
+            d.day == currentDate.day,
+      ),
       orElse:
           () => MarkedDaysModel(
             selectedDateList: [],
@@ -66,7 +80,7 @@ class CalendarDateCell extends StatelessWidget {
     final bool isUserPicked = provider.userPicked == i;
     final bool isInRange = provider.isRangeSelection && provider.isInRange(i);
 
-    final BoxDecoration finalDecoration =
+    BoxDecoration finalDecoration =
         isInRange
             ? getRangeDecoration(
               context: context,
@@ -95,11 +109,30 @@ class CalendarDateCell extends StatelessWidget {
         isInRange
             ? const EdgeInsets.symmetric(horizontal: 0, vertical: 4)
             : const EdgeInsets.all(4);
+    final EdgeInsets finalPadding =
+        isInRange && cellPadding != null
+            ? EdgeInsets.zero
+            : cellPadding ?? const EdgeInsets.all(12);
+
+    bool rangePickHold =
+        provider.rangeStart != null &&
+        provider.rangeEnd == null &&
+        provider.rangeStart == i;
+    finalDecoration =
+        rangePickHold
+            ? (userPickedDecoration != null
+                ? userPickedDecoration!.copyWith(
+                  color: userPickedDecoration!.color?.withValues(alpha: 128),
+                )
+                : selectedModel.decoration.copyWith(
+                  color: Colors.teal.shade400.withValues(alpha: 128),
+                ))
+            : finalDecoration;
 
     return GestureDetector(
       onTap: () => provider.toggleUserPicked(i),
       child: Container(
-        padding: const EdgeInsets.all(12),
+        padding: finalPadding,
         margin: finalMargin,
         decoration: finalDecoration,
         child: finalChild,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: m_calendar
 description: "A customizable and lightweight Flutter calendar widget package supporting day and list-based selections with user-defined decorations."
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/MuntasirAsif/m_calendar
 repository: https://github.com/MuntasirAsif/m_calendar
 issue_tracker: https://github.com/MuntasirAsif/m_calendar/issues


### PR DESCRIPTION
Add Feature #13 : Pass the pick date date

- User can get the pick date data as a list of DateTime, not just a single DateTime.
- Modularized `CalendarDateCell` and `getRangeDecoration` logic
- Fixed logical prioritization in decoration application for user-picked and range cells
- Improved `MCalendar` UI with card layout, theme consistency, and styling polish
- Added full Dart documentation for all public classes and functions